### PR TITLE
Fix typo in architecture.md

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -54,5 +54,5 @@ components of the app:
 * `users` - user display, search and selection
 
 
-`ZulipApp.js` contains the top-level React component for the app and
+`ZulipMobile.js` contains the top-level React component for the app and
 `reducers.js` contains the top-level reducer.


### PR DESCRIPTION
Its a type as there is no file names ZulipMobile.js